### PR TITLE
fix: rename podspec to match the new package name

### DIFF
--- a/IntuifaceCapacitorPluginScreenshot.podspec
+++ b/IntuifaceCapacitorPluginScreenshot.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapacitorPluginScreenshot'
+  s.name = 'IntuifaceCapacitorPluginScreenshot'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "CapacitorPluginScreenshot.podspec"
+    "IntuifaceCapacitorPluginScreenshot.podspec"
   ],
   "author": "intuiface",
   "license": "MIT",


### PR DESCRIPTION
The podespec has a wrong name since we change the name of the package when we wanted to publish it under our organization. 
This PR fixes this issue