### PR TITLE
fix: take into account a size property for the snapshot

### DIFF
--- a/android/src/main/java/com/intuiface/plugins/screenshot/CapacitorScreenshotPlugin.java
+++ b/android/src/main/java/com/intuiface/plugins/screenshot/CapacitorScreenshotPlugin.java
@@ -194,8 +194,9 @@ public class CapacitorScreenshotPlugin extends Plugin {
         // generate the final bitmap at the right size from the bitmap created
         bitmap = Bitmap.createBitmap(bitmap, 0, 0, width, height);
 
+        int desiredWidth = savedCall.getInt("size", width);
         // scale but keep ratio
-        int scaledWidth = Math.min(width, 1920);
+        int scaledWidth = Math.min(width, desiredWidth);
         int scaledHeight = height * scaledWidth / width;
         bitmap = Bitmap.createScaledBitmap(bitmap, scaledWidth, scaledHeight, false);
 

--- a/ios/Plugin/CapacitorScreenshotPlugin.swift
+++ b/ios/Plugin/CapacitorScreenshotPlugin.swift
@@ -13,6 +13,7 @@ public class CapacitorScreenshotPlugin: CAPPlugin {
 
         let quality = ((call.getDouble("quality") ?? 100) / 100)
         let filename = (call.getString("name") ?? "screenshot")
+        
         DispatchQueue.main.async {
             let config = WKSnapshotConfiguration()
             config.rect = self.webView!.frame
@@ -22,7 +23,23 @@ public class CapacitorScreenshotPlugin: CAPPlugin {
                 if error != nil {
                     return
                 }
-                guard let imageData = image!.jpegData(compressionQuality: quality) else {return}
+
+                let imageSize = image?.size;
+                var newImage = image;
+                if(imageSize != nil)
+                {
+                    let size = (call.getDouble("size") ?? Double(imageSize!.width))
+                    
+                    // compute the new size of the image
+                    let width = Double.minimum(imageSize!.width, size);
+                    let height = imageSize!.height * width / imageSize!.width;
+                    let newSize: CGSize = CGSize(width: width, height: height);
+                    
+                    // resize the image
+                    newImage = image?.imageWith(newSize: newSize);
+                }
+
+                guard let imageData = newImage!.jpegData(compressionQuality: quality) else {return}
                 let base64Result = imageData.base64EncodedString()
                 let file = "data:image/png;base64," + base64Result
 
@@ -45,5 +62,17 @@ public class CapacitorScreenshotPlugin: CAPPlugin {
                 ])
             })
         }
+    }
+
+    
+}
+
+extension UIImage {
+    func imageWith(newSize: CGSize) -> UIImage {
+        let image = UIGraphicsImageRenderer(size: newSize).image { _ in
+            draw(in: CGRect(origin: .zero, size: newSize))
+        }
+        
+        return image.withRenderingMode(renderingMode)
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -9,6 +9,10 @@ export interface CapacitorScreenshotPlugin {
 
 export interface ScreenshotOptions {
   /**
+   * The desired size (here width) of the screenshot
+   */
+  size: number;
+  /**
    * The quality of the screenshot between 0-100
    */
   quality: number;

--- a/src/web.ts
+++ b/src/web.ts
@@ -51,10 +51,18 @@ export class CapacitorScreenshotWeb
           // set the canvas size with the video size
           this.captureCanvas.width = this.videoCapture.videoWidth;
           this.captureCanvas.height = this.videoCapture.videoHeight;
+          let newWidth = this.captureCanvas.width;
+          let newHeight = this.captureCanvas.height;
+          if (options.size) {
+            newWidth = options.size;
+            newHeight = this.captureCanvas.height * newWidth / this.captureCanvas.width;
+            this.captureCanvas.width = newWidth;
+            this.captureCanvas.height = newHeight;
+          }
           // draw the video into canvas
           this.captureCanvas
             .getContext('2d')
-            .drawImage(this.videoCapture, 0, 0);
+            .drawImage(this.videoCapture, 0, 0, newWidth, newHeight);
           let quality = 1.0;
           if (options.quality) {
             quality = options.quality / 100;


### PR DESCRIPTION
Add a size option to avoid creating a too big image when it is not usefull
It fix a ticket we have : https://intuilab.atlassian.net/browse/PN-3439